### PR TITLE
Settable default swipeBackEnabled value.

### DIFF
--- a/Demo/SwipeBackDemo.xcodeproj/project.pbxproj
+++ b/Demo/SwipeBackDemo.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		03E1867519C9D56E00A2914E /* DemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E1867419C9D56E00A2914E /* DemoViewController.m */; };
 		03E1FD4F1A2B0D79009F776D /* UINavigationController+SwipeBack.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E1FD4C1A2B0D79009F776D /* UINavigationController+SwipeBack.m */; };
 		03E1FD501A2B0D79009F776D /* UIViewController+SwipeBack.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E1FD4E1A2B0D79009F776D /* UIViewController+SwipeBack.m */; };
+		954286951CF834F500EAD6B9 /* SwipeBackDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 954286941CF834F500EAD6B9 /* SwipeBackDefaults.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +63,8 @@
 		04D87589A9D3073CBA59E925 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		4DFFADCEFB754AB1A539322E /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F558BACAC8C6C7BD92EE927 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		954286931CF834F500EAD6B9 /* SwipeBackDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwipeBackDefaults.h; sourceTree = "<group>"; };
+		954286941CF834F500EAD6B9 /* SwipeBackDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SwipeBackDefaults.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,6 +175,8 @@
 				03E1FD4C1A2B0D79009F776D /* UINavigationController+SwipeBack.m */,
 				03E1FD4D1A2B0D79009F776D /* UIViewController+SwipeBack.h */,
 				03E1FD4E1A2B0D79009F776D /* UIViewController+SwipeBack.m */,
+				954286931CF834F500EAD6B9 /* SwipeBackDefaults.h */,
+				954286941CF834F500EAD6B9 /* SwipeBackDefaults.m */,
 			);
 			name = SwipeBack;
 			path = ../../SwipeBack;
@@ -284,6 +289,7 @@
 				033BDD7619C9D339004A8851 /* AppDelegate.m in Sources */,
 				03E1867519C9D56E00A2914E /* DemoViewController.m in Sources */,
 				033BDD7219C9D339004A8851 /* main.m in Sources */,
+				954286951CF834F500EAD6B9 /* SwipeBackDefaults.m in Sources */,
 				03E1FD501A2B0D79009F776D /* UIViewController+SwipeBack.m in Sources */,
 				03E1FD4F1A2B0D79009F776D /* UINavigationController+SwipeBack.m in Sources */,
 			);

--- a/SwipeBack/SwipeBack.h
+++ b/SwipeBack/SwipeBack.h
@@ -25,3 +25,4 @@
 
 #import "UINavigationController+SwipeBack.h"
 #import "UIViewController+SwipeBack.h"
+#import "SwipeBackDefaults.h"

--- a/SwipeBack/SwipeBackDefaults.h
+++ b/SwipeBack/SwipeBackDefaults.h
@@ -1,13 +1,33 @@
 //
-//  SwipeBackDefaults.h
-//  SwipeBackDemo
+// The MIT License (MIT)
 //
-//  Created by KimTae jun on 2016. 5. 27..
-//  Copyright © 2016년 Suyeol Jeon. All rights reserved.
+// Copyright (c) 2014 Suyeol Jeon
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 //
 
 #import <Foundation/Foundation.h>
 
 @interface SwipeBackDefaults : NSObject
+
+@property (nonatomic) BOOL swipeBackEnabled;
+
++ (SwipeBackDefaults *)defaults;
 
 @end

--- a/SwipeBack/SwipeBackDefaults.h
+++ b/SwipeBack/SwipeBackDefaults.h
@@ -1,0 +1,13 @@
+//
+//  SwipeBackDefaults.h
+//  SwipeBackDemo
+//
+//  Created by KimTae jun on 2016. 5. 27..
+//  Copyright © 2016년 Suyeol Jeon. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SwipeBackDefaults : NSObject
+
+@end

--- a/SwipeBack/SwipeBackDefaults.m
+++ b/SwipeBack/SwipeBackDefaults.m
@@ -1,0 +1,13 @@
+//
+//  SwipeBackDefaults.m
+//  SwipeBackDemo
+//
+//  Created by KimTae jun on 2016. 5. 27..
+//  Copyright © 2016년 Suyeol Jeon. All rights reserved.
+//
+
+#import "SwipeBackDefaults.h"
+
+@implementation SwipeBackDefaults
+
+@end

--- a/SwipeBack/SwipeBackDefaults.m
+++ b/SwipeBack/SwipeBackDefaults.m
@@ -1,13 +1,52 @@
 //
-//  SwipeBackDefaults.m
-//  SwipeBackDemo
+// The MIT License (MIT)
 //
-//  Created by KimTae jun on 2016. 5. 27..
-//  Copyright © 2016년 Suyeol Jeon. All rights reserved.
+// Copyright (c) 2014 Suyeol Jeon
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 //
 
 #import "SwipeBackDefaults.h"
 
 @implementation SwipeBackDefaults
+
++ (SwipeBackDefaults *)defaults
+{
+    static SwipeBackDefaults *defaults = nil;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        defaults = [[SwipeBackDefaults alloc] init];
+    });
+    
+    return defaults;
+}
+
+#pragma mark - Init
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _swipeBackEnabled = YES;
+    }
+    return self;
+}
 
 @end

--- a/SwipeBack/UINavigationController+SwipeBack.m
+++ b/SwipeBack/UINavigationController+SwipeBack.m
@@ -24,7 +24,7 @@
 
 #import <objc/runtime.h>
 #import "UINavigationController+SwipeBack.h"
-
+#import "SwipeBackDefaults.h"
 
 void __swipeback_swizzle(Class cls, SEL originalSelector) {
     NSString *originalName = NSStringFromSelector(originalSelector);
@@ -111,7 +111,7 @@ void __swipeback_swizzle(Class cls, SEL originalSelector) {
 {
     NSNumber *enabled = objc_getAssociatedObject(self, @selector(swipeBackEnabled));
     if (enabled == nil) {
-        return YES; // default value
+        return [SwipeBackDefaults defaults].swipeBackEnabled; // default value
     }
     return enabled.boolValue;
 }


### PR DESCRIPTION
## Why?

The default value of `swipeBackEnabled` is `YES` now.
But, in my case, I have to set `swipeBackEnabled` enabled in just few navigation controllers.
## So...

I wanted to set the default value of `swipeBackEnabled`.
I just added a `SwipeBackDefaults` class with a singleton method.
## For example,

Just add a line below into your App delegate -application:didFinishLaunchingWithOptions:

``` obj-c
[SwipeBackDefaults defaults].swipeBackEnabled = NO;
```
